### PR TITLE
Bump django from 4.2.16 to 4.2.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 crispy-bootstrap5==2024.2
 cryptography==43.0.1
 dj-database-url==2.2.0
-Django==4.2.16
+Django==4.2.17
 django-appconf==1.0.6
 django-bootstrap5==24.2
 django-crispy-forms==2.2


### PR DESCRIPTION
### Vulnerabilities Fixed

- **SQL Injection**:
  Direct usage of the `django.db.models.fields.json.HasKey` lookup, when an Oracle database is used, is subject to SQL injection if untrusted data is used as an lhs value.
(*Note: Applications that use the `jsonfield.has_key` lookup via __ are unaffected.*)

- **Denial-of-Service (DoS)**:
  The `strip_tags()` method and `striptags template filter` are subject to a potential denial-of-service attack via certain inputs containing large sequences of nested incomplete HTML entities.
