### PR TITLE
Bump django from 4.2.17 to 4.2.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click==8.1.7
 crispy-bootstrap5==2024.2
 cryptography==43.0.1
 dj-database-url==2.2.0
-Django==4.2.17
+Django==4.2.18
 django-appconf==1.0.6
 django-bootstrap5==24.2
 django-crispy-forms==2.2


### PR DESCRIPTION
**Fix: Denial-of-Service (DoS) Vulnerability in IPv6 Validation**

This PR addresses a **Denial-of-Service (DoS) vulnerability** caused by the lack of upper-bound limit enforcement in strings passed during IPv6 validation. An attacker could exploit this issue to cause excessive resource consumption.

Affected Components: `clean_ipv6_address`, `is_valid_ipv6_address`, `django.forms.GenericIPAddressField`
