### PR TITLE
Deprecate Cloudflare captcha verification in register form

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 - [X] **Password Health Monitoring**: Built-in tool to check the strength and health of stored passwords, identifying `weak`, `reused`, or `compromised` passwords.
 - [X] **Import/Export Data**: `Upload` data such as passwords from a CSV file or `download` your stored data in `CSV` format for easy backup or migration.
 - [X] **Automatic Logout**: Automatically logs you out after a **customizable** period of inactivity. Choose the **timeout** duration that best suits your needs.
-- [X] **Cloudflare CAPTCHA Verification**: Protects against automated attacks by using CAPTCHA to verify human users.
 
 ## Purpose
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -43,7 +43,6 @@ INSTALLED_APPS = [
     "django_bootstrap5",
     "crispy_forms",
     "crispy_bootstrap5",
-    "turnstile",
     # Default django apps
     "django.contrib.admin",
     "django.contrib.auth",
@@ -182,8 +181,3 @@ EMAIL_HOST = "smtp.gmail.com"
 EMAIL_PORT = 587
 EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
-
-# Turnstile settings (DEBUG=False)
-if not DEBUG:
-    TURNSTILE_SITEKEY = os.getenv("TURNSTILE_SITEKEY")
-    TURNSTILE_SECRET = os.getenv("TURNSTILE_SECRET")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ django-appconf==1.0.6
 django-bootstrap5==24.2
 django-crispy-forms==2.2
 django-extensions==3.2.3
-django-turnstile==0.1.0
 future==1.0.0
 gunicorn==22.0.0
 h11==0.14.0

--- a/users/forms.py
+++ b/users/forms.py
@@ -1,6 +1,5 @@
 import pyotp
 from django.contrib.auth import get_user_model
-from turnstile.fields import TurnstileField
 from .models import CustomUser
 from django import forms
 from django.contrib.auth.forms import (
@@ -17,11 +16,10 @@ class CustomUserCreationForm(UserCreationForm):
     password2 = forms.CharField(
         label="Confirm Master Password", widget=forms.PasswordInput, required=True
     )
-    captcha_verification = TurnstileField(theme="light", size="flexible")
 
     class Meta:
         model = CustomUser
-        fields = ("email", "username", "password1", "password2", "captcha_verification")
+        fields = ("email", "username", "password1", "password2")
 
     def clean(self):
         """

--- a/users/tests/test_forms.py
+++ b/users/tests/test_forms.py
@@ -1,7 +1,7 @@
 import pyotp
 from django.test import TestCase
 from django.contrib.auth import get_user_model
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from ..forms import (
     CustomUserCreationForm,
     CustomAuthenticationForm,
@@ -11,7 +11,6 @@ from ..forms import (
 )
 
 
-@patch("turnstile.fields.TurnstileField.validate", return_value=True)
 class CustomUserCreationFormTests(TestCase):
     """
     Test suite for the CustomUserCreationForm.
@@ -26,7 +25,6 @@ class CustomUserCreationFormTests(TestCase):
             "username": "testuser",
             "password1": "SecRet_p@ssword",
             "password2": "SecRet_p@ssword",
-            "captcha_verification": "testsecret",
         }
 
         self.invalid_data = {
@@ -34,24 +32,23 @@ class CustomUserCreationFormTests(TestCase):
             "username": "testuser",
             "password1": "SecRet_p@ssword",
             "password2": "SecRetp@ssword",
-            "captcha_verification": "testsecret",
         }
 
-    def test_form_valid_data(self, mock: MagicMock):
+    def test_form_valid_data(self):
         """
         Test that the form is valid when all fields are provided and passwords match.
         """
         form = CustomUserCreationForm(data=self.valid_data)
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_form_invalid_data(self, mock: MagicMock):
+    def test_form_invalid_data(self):
         """
         Test that the form is invalid when passwords do not match.
         """
         form = CustomUserCreationForm(data=self.invalid_data)
         self.assertFalse(form.is_valid(), form.errors)
 
-    def test_form_missing_email(self, mock: MagicMock):
+    def test_form_missing_email(self):
         """
         Test that the form is invalid when the email is missing.
         """
@@ -60,7 +57,7 @@ class CustomUserCreationFormTests(TestCase):
         form = CustomUserCreationForm(data=data)
         self.assertFalse(form.is_valid(), form.errors)
 
-    def test_form_missing_username(self, mock: MagicMock):
+    def test_form_missing_username(self):
         """
         Test that the form is invalid when the username is missing.
         """

--- a/users/tests/test_views.py
+++ b/users/tests/test_views.py
@@ -1,6 +1,6 @@
 import pyotp
 from django.test import TestCase
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.contrib.auth import SESSION_KEY
@@ -14,7 +14,6 @@ from ..forms import (
 )
 
 
-@patch("turnstile.fields.TurnstileField.validate", return_value=True)
 class RegisterViewTests(TestCase):
     """
     Test case for the register view.
@@ -30,10 +29,9 @@ class RegisterViewTests(TestCase):
             "username": "testuser",
             "password1": "testpassword123",
             "password2": "testpassword123",
-            "captcha_verification": "testsecret",
         }
 
-    def test_register_view_status_code_and_template(self, mock: MagicMock):
+    def test_register_view_status_code_and_template(self):
         """
         Test if the register view returns a status code 200 & uses the correct template.
         """
@@ -42,7 +40,7 @@ class RegisterViewTests(TestCase):
         self.assertTemplateUsed(response, "registration/register.html")
         self.assertIsInstance(response.context["form"], CustomUserCreationForm)
 
-    def test_register_view_valid(self, mock: MagicMock):
+    def test_register_view_valid(self):
         """
         Test registering a new user with valid data.
         """
@@ -57,7 +55,7 @@ class RegisterViewTests(TestCase):
         # Check if the user is still logged out
         self.assertNotIn(SESSION_KEY, self.client.session)
 
-    def test_register_view_post_invalid(self, mock: MagicMock):
+    def test_register_view_post_invalid(self):
         """
         Test registering a new user with invalid data.
         """


### PR DESCRIPTION
Deprecated as it's unsuitable for a locally `self hosted`, `non business` application.