### PR TITLE
Bump gunicorn from 22.0.0 to 23.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-bootstrap5==24.2
 django-crispy-forms==2.2
 django-extensions==3.2.3
 future==1.0.0
-gunicorn==22.0.0
+gunicorn==23.0.0
 h11==0.14.0
 packaging==24.1
 psycopg2-binary==2.9.9


### PR DESCRIPTION
Fix: **Gunicorn HTTP Request/Response Smuggling vulnerability (CVE-2024-6827)**

This PR addresses a **request smuggling vulnerability in gunicorn** caused by improper validation of the `Transfer-Encoding` header. Due to fallback behavior to `Content-Length` attackers can exploit this flaw to manipulate request handling leading to potential security risks such as cache poisoning, data exposure and SSRF.