### PR TITLE
Bump h11 from 0.14.0 to 0.16.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-crispy-forms==2.2
 django-extensions==3.2.3
 future==1.0.0
 gunicorn==23.0.0
-h11==0.14.0
+h11==0.16.0
 packaging==24.1
 psycopg2-binary==2.9.9
 pwnedpasswords==2.0.0


### PR DESCRIPTION
Fix: **h11 Chunked Encoding Request Smuggling Vulnerability (CVE-2025-43859)**

This PR addresses a **chunked encoding request smuggling vulnerability in h11** caused by improper parsing of HTTP chunked bodies which accepted invalid line endings. When combined with a buggy `reverse proxy` attackers could "smuggle" hidden HTTP requests past the proxy potentially bypassing **security measures** or **stealing session data**.